### PR TITLE
add temp CI job to test syspolicy impact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,3 +20,21 @@ jobs:
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
     - name: Build
       run: make ci
+  macos_perf_test:
+    runs-on: macos-latest
+    steps:
+    - name: Disable syspolicy assessments
+      run: |
+        spctl --status
+        sudo spctl --master-disable
+    - uses: actions/checkout@v2
+    - name: Install Nix
+      uses: cachix/install-nix-action@v10
+    - name: Install Cachix
+      uses: cachix/cachix-action@v6
+      with:
+        name: martinbaillie
+        signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+    - name: Build
+      run: make ci
+      


### PR DESCRIPTION
Starting in Catalina, macOS runs a syspolicyd "assessment" that hits the network for each binary/script executable. It does cache these results, but Nix tends to introduce many "new" executables per build. (You can read more about this at https://github.com/NixOS/nix/issues/3789).

This PR adds a temporary, redundant macOS job with these assessments disabled. I'm hoping you can adopt it for a few weeks to help me collect more data on how this affects real projects.

(I guess this may not run on PR since they're only set to run on master. For reference, I enabled and ran these in a separate branch https://github.com/nix-macos-perf-test/dotfiles/actions/runs/162700190)