### PR TITLE
Revert "add temp CI job to test syspolicy impact"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,20 +20,3 @@ jobs:
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
     - name: Build
       run: make ci
-  macos_perf_test:
-    runs-on: macos-latest
-    steps:
-    - name: Disable syspolicy assessments
-      run: |
-        spctl --status
-        sudo spctl --master-disable
-    - uses: actions/checkout@v2
-    - name: Install Nix
-      uses: cachix/install-nix-action@v10
-    - name: Install Cachix
-      uses: cachix/cachix-action@v6
-      with:
-        name: martinbaillie
-        signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-    - name: Build
-      run: make ci


### PR DESCRIPTION
Reverts #1

Thanks for your help testing this out. The results were a bit of a bust with respect to any short-term hope of speeding up macOS builds, but they did help me tease out the fact that the approach I used here doesn't actually disable the whole assessment--it seems to just keep the result of the assessment from being used.

With the approach used here ruled out, the only way I'm aware of to fully disable the assessments and reclaim the associated time requires a GUI to set up. :/